### PR TITLE
Association assignments are broken

### DIFF
--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -61,6 +61,14 @@ class TestDeepCloneable < Test::Unit::TestCase
     assert_equal 1, clone.gold_pieces.size
   end
 
+  def test_include_association_assignments
+    clone = @jack.clone(:include => :treasures)
+
+    clone.treasures.each do |treasure|
+      assert_equal clone, treasure.pirate
+    end
+  end
+
   def test_multiple_and_deep_include_association
     clone = @jack.clone(:include => {:treasures => :gold_pieces, :mateys => {}})
     assert clone.save


### PR DESCRIPTION
I added a failing test to show that association assignments are broken.

This commit breaks it. https://github.com/moiristo/deep_cloneable/commit/976b11b44748dbe75612a673fa1a3b3df3de2d7b#L1R82
The problem is that primary_key_column expects an integer value, not AR object.
