### PR TITLE
HABTM associations cause duped record to be saved

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -122,7 +122,7 @@ class ActiveRecord::Base
               end.try(:name)
 
               self.send(association).collect do |obj|
-                obj.send(reverse_association_name) << kopy
+                obj.send(reverse_association_name).target << kopy
                 obj
               end
           end

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -16,6 +16,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_single_dup_exception
     dup = @jack.send(@@clone_method, :except => :name)
+    assert dup.new_record?
     assert dup.save
     assert_equal @jack.name, @jack.send(@@clone_method).name # Old behaviour
     assert_nil dup.name
@@ -24,6 +25,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_multiple_dup_exception
     dup = @jack.send(@@clone_method, :except => [:name, :nick_name])
+    assert dup.new_record?
     assert dup.save
     assert_nil dup.name
     assert_equal 'no nickname', dup.nick_name
@@ -32,12 +34,14 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_single_include_association
     dup = @jack.send(@@clone_method, :include => :mateys)
+    assert dup.new_record?
     assert dup.save
     assert_equal 1, dup.mateys.size
   end
 
   def test_single_include_belongs_to_polymorphic_association
     dup = @jack.send(@@clone_method, :include => :ship)
+    assert dup.new_record?
     assert dup.save
     assert_not_nil dup.ship
     assert_not_equal @jack.ship, dup.ship
@@ -45,12 +49,14 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_single_include_has_many_polymorphic_association
     dup = @ship.send(@@clone_method, :include => :pirates)
+    assert dup.new_record?
     assert dup.save
     assert dup.pirates.any?
   end
 
   def test_multiple_include_association
     dup = @jack.send(@@clone_method, :include => [:mateys, :treasures])
+    assert dup.new_record?
     assert dup.save
     assert_equal 1, dup.mateys.size
     assert_equal 1, dup.treasures.size
@@ -58,6 +64,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_deep_include_association
     dup = @jack.send(@@clone_method, :include => {:treasures => :gold_pieces})
+    assert dup.new_record?
     assert dup.save
     assert_equal 1, dup.treasures.size
     assert_equal 1, dup.gold_pieces.size
@@ -65,6 +72,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_include_association_assignments
     dup = @jack.send(@@clone_method, :include => :treasures)
+    assert dup.new_record?
 
     dup.treasures.each do |treasure|
       assert_equal dup, treasure.pirate
@@ -73,6 +81,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_multiple_and_deep_include_association
     dup = @jack.send(@@clone_method, :include => {:treasures => :gold_pieces, :mateys => {}})
+    assert dup.new_record?
     assert dup.save
     assert_equal 1, dup.treasures.size
     assert_equal 1, dup.gold_pieces.size
@@ -81,6 +90,7 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_multiple_and_deep_include_association_with_array
     dup = @jack.send(@@clone_method, :include => [{:treasures => :gold_pieces}, :mateys])
+    assert dup.new_record?
     assert dup.save
     assert_equal 1, dup.treasures.size
     assert_equal 1, dup.gold_pieces.size
@@ -89,12 +99,14 @@ class TestDeepCloneable < Test::Unit::TestCase
 
   def test_with_belongs_to_relation
     dup = @jack.send(@@clone_method, :include => :parrot)
+    assert dup.new_record?
     assert dup.save
     assert_not_equal dup.parrot, @jack.parrot
   end
 
   def test_should_pass_nested_exceptions
     dup = @jack.send(@@clone_method, :include => :parrot, :except => [:name, { :parrot => [:name] }])
+    assert dup.new_record?
     assert dup.save
     assert_not_equal dup.parrot, @jack.parrot
     assert_not_nil @jack.parrot.name
@@ -104,6 +116,7 @@ class TestDeepCloneable < Test::Unit::TestCase
   def test_should_not_double_dup_when_using_dictionary
     current_matey_count = Matey.count
     dup = @jack.send(@@clone_method, :include => [:mateys, { :treasures => :matey }], :use_dictionary => true)
+    assert dup.new_record?
     dup.save!
 
     assert_equal current_matey_count + 1, Matey.count
@@ -116,6 +129,7 @@ class TestDeepCloneable < Test::Unit::TestCase
     @jack.mateys.each{|m| dict[:mateys][m] = m.send(@@clone_method) }
 
     dup = @jack.send(@@clone_method, :include => [:mateys, { :treasures => :matey }], :dictionary => dict)
+    assert dup.new_record?
     dup.save!
 
     assert_equal current_matey_count + 1, Matey.count
@@ -126,6 +140,7 @@ class TestDeepCloneable < Test::Unit::TestCase
     @pig = Animal::Pig.create :human => @human, :name => 'big pig'
 
     dup_human = @human.send(@@clone_method, :include => [:pigs])
+    assert dup_human.new_record?
     assert dup_human.save
     assert_equal 1, dup_human.pigs.count
     
@@ -133,6 +148,7 @@ class TestDeepCloneable < Test::Unit::TestCase
     @pig2 = @human2.pigs.create :name => 'small pig'
     
     dup_human_2 = @human.send(@@clone_method, :include => [:pigs])
+    assert dup_human_2.new_record?
     assert dup_human_2.save
     assert_equal 1, dup_human_2.pigs.count
   end 
@@ -146,6 +162,7 @@ class TestDeepCloneable < Test::Unit::TestCase
     @human2.chickens << [@chicken1, @chicken2]    
     
     dup_human = @human.send(@@clone_method, :include => :ownerships)
+    assert dup_human.new_record?
     assert dup_human.save
     assert_equal 2, dup_human.chickens.count    
   end 
@@ -155,6 +172,7 @@ class TestDeepCloneable < Test::Unit::TestCase
       kopy.cloned_from_id = original.id
     end
 
+    assert dup.new_record?
     assert dup.save
     assert_equal @jack.id, dup.cloned_from_id
     assert_equal @jack.parrot.id, dup.parrot.cloned_from_id
@@ -169,13 +187,18 @@ class TestDeepCloneable < Test::Unit::TestCase
     @person2.cars << [@car1, @car2]
 
     dup_person = @person1.dup :include => :cars
+
+    assert dup_person.new_record?
+    assert_equal [@person1, @person2, dup_person], @car1.people
+    assert_equal [@person1, @person2, dup_person], @car2.people
+
     assert dup_person.save
 
     # did NOT dup the Car instances
     assert_equal 2, Car.all.count
 
     # did dup the correct join table rows
-    assert_equal dup_person.cars, @person1.cars
+    assert_equal @person1.cars, dup_person.cars
     assert_equal 2, dup_person.cars.count
   end
   


### PR DESCRIPTION
When deep cloning a record with a `has_and_belongs_to_many` association the duped record is automatically saved due to the use of [`<<`](http://apidock.com/rails/v3.0.9/ActiveRecord/Associations/AssociationCollection/%3C%3C) on the association.

The attached patch fixes this issue by injecting the duped record into the `target` of the reverse associations instead of the `CollectionProxy` itself. It also adds assertions for each existing test to ensure that the duped record is a `new_record?`.
