### PR TITLE
Fixing primary key assignment for habtm association

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -91,7 +91,7 @@ class ActiveRecord::Base
               
               self.send(association).collect do |obj| 
                 tmp = obj.send(__method__, opts)
-                tmp.send("#{primary_key_name}=", nil)                
+                tmp.send("#{primary_key_name}=", nil) if tmp.respond_to?("#{primary_key_name}=")
                 tmp.send("#{reverse_association_name.to_s}=", kopy) if reverse_association_name
                 tmp
               end


### PR DESCRIPTION
Looks like `deep_cloneable` is treating a HABTM relationship the same as a has_many relationship, which results in an exception because `deep_cloneable` tries to assign the primary key of the cloned object.  HABTM relationships use join tables, so assigning a primary key doesn't work.  This PR just makes sure the cloned object responds to the call to `#{primary_key}=` before calling it.
