### PR TITLE
Added validate: false to skip validations when saving the cloned tree.

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -17,52 +17,52 @@ class ActiveRecord::Base
       end
     end
 
-    # clones an ActiveRecord model. 
+    # clones an ActiveRecord model.
     # if passed the :include option, it will deep clone the given associations
     # if passed the :except option, it won't clone the given attributes
     #
     # === Usage:
-    # 
+    #
     # ==== Cloning one single association
     #    pirate.clone :include => :mateys
-    # 
+    #
     # ==== Cloning multiple associations
     #    pirate.clone :include => [:mateys, :treasures]
-    # 
+    #
     # ==== Cloning really deep
     #    pirate.clone :include => {:treasures => :gold_pieces}
-    # 
+    #
     # ==== Cloning really deep with multiple associations
     #    pirate.clone :include => [:mateys, {:treasures => :gold_pieces}]
     #
     # ==== Cloning really deep with multiple associations and a dictionary
     #
-    # A dictionary ensures that models are not cloned multiple times when it is associated to nested models. 
+    # A dictionary ensures that models are not cloned multiple times when it is associated to nested models.
     # When using a dictionary, ensure recurring associations are cloned first:
     #
-    #    pirate.clone :include => [:mateys, {:treasures => [:matey, :gold_pieces], :use_dictionary => true }]    
+    #    pirate.clone :include => [:mateys, {:treasures => [:matey, :gold_pieces], :use_dictionary => true }]
     #
     # If this is not an option for you, it is also possible to populate the dictionary manually in advance:
     #
     #    dict = { :mateys => {} }
     #    pirate.mateys.each{|m| dict[:mateys][m] = m.clone }
-    #    pirate.clone :include => [:mateys, {:treasures => [:matey, :gold_pieces], :dictionary => dict }]    
-    #   
+    #    pirate.clone :include => [:mateys, {:treasures => [:matey, :gold_pieces], :dictionary => dict }]
+    #
     # ==== Cloning a model without an attribute
     #    pirate.clone :except => :name
-    #  
+    #
     # ==== Cloning a model without multiple attributes
     #    pirate.clone :except => [:name, :nick_name]
-    #    
-    # ==== Cloning a model without an attribute or nested multiple attributes   
+    #
+    # ==== Cloning a model without an attribute or nested multiple attributes
     #    pirate.clone :include => :parrot, :except => [:name, { :parrot => [:name] }]
-    # 
+    #
     define_method :dup do |*args, &block|
       options = args[0] || {}
-      
+
       dict = options[:dictionary]
       dict ||= {} if options.delete(:use_dictionary)
-      
+
       kopy = unless dict
         super()
       else
@@ -81,40 +81,50 @@ class ActiveRecord::Base
         end
         deep_exceptions = exceptions.select{|e| e.kind_of?(Hash) }.inject({}){|m,h| m.merge(h) }
       end
-    
+
       if options[:include]
         Array(options[:include]).each do |association, deep_associations|
           if (association.kind_of? Hash)
             deep_associations = association[association.keys.first]
             association = association.keys.first
           end
-          
+
           opts = deep_associations.blank? ? {} : {:include => deep_associations}
           opts.merge!(:except => deep_exceptions[association]) if deep_exceptions[association]
           opts.merge!(:dictionary => dict) if dict
-        
+
           association_reflection = self.class.reflect_on_association(association)
           raise AssociationNotFoundException.new("#{self.class}##{association}") if association_reflection.nil?
-                    
+
+          if options[:validate] == false
+            kopy.instance_eval do
+              # Force :validate => false on all saves.
+              def perform_validations(options={})
+                options[:validate] = false
+                super(options)
+              end
+            end
+          end
+
           cloned_object = case association_reflection.macro
             when :belongs_to, :has_one
               self.send(association) && self.send(association).send(__method__, opts, &block)
             when :has_many
               primary_key_name = association_reflection.foreign_key.to_s
-              
+
               reverse_association_name = association_reflection.klass.reflect_on_all_associations.detect do |a|
                 a.foreign_key.to_s == primary_key_name
               end.try(:name)
-              
-              self.send(association).collect do |obj| 
+
+              self.send(association).collect do |obj|
                 tmp = obj.send(__method__, opts, &block)
-                tmp.send("#{primary_key_name}=", nil)                
+                tmp.send("#{primary_key_name}=", nil)
                 tmp.send("#{reverse_association_name.to_s}=", kopy) if reverse_association_name
                 tmp
               end
             when :has_and_belongs_to_many
               primary_key_name = association_reflection.foreign_key.to_s
-                            
+
               reverse_association_name = association_reflection.klass.reflect_on_all_associations.detect do |a|
                 (a.macro == :has_and_belongs_to_many) && (a.association_foreign_key.to_s == primary_key_name)
               end.try(:name)
@@ -124,16 +134,16 @@ class ActiveRecord::Base
                 obj
               end
           end
-          
+
           kopy.send("#{association}=", cloned_object)
         end
       end
 
       return kopy
     end
-    
-    class AssociationNotFoundException < StandardError; end    
+
+    class AssociationNotFoundException < StandardError; end
   end
-  
+
   include DeepCloneable
 end

--- a/test/models.rb
+++ b/test/models.rb
@@ -1,25 +1,26 @@
 module Animal
   class Human < ActiveRecord::Base
     has_many :pigs
-    
-    has_many :ownerships    
+
+    has_many :ownerships
     has_many :chickens, :through => :ownerships
   end
   class Pig < ActiveRecord::Base
     belongs_to :human
   end
-      
+
   class Chicken < ActiveRecord::Base
     has_many :ownerships
     has_many :humans, :through => :ownerships
-  end  
-  
+  end
+
   class Ownership < ActiveRecord::Base
     belongs_to :human
     belongs_to :chicken
-    
+
     validates_uniqueness_of :chicken_id, :scope => :human_id
-  end  
+  end
+
 end
 
 class GoldPiece < ActiveRecord::Base;   belongs_to :treasure  end
@@ -50,4 +51,14 @@ end
 
 class Car < ActiveRecord::Base
   has_and_belongs_to_many :people
+end
+
+class ChildWithValidation < ActiveRecord::Base
+  belongs_to :parent, :class_name => 'ParentWithValidation'
+  validates :name, :presence => true
+end
+
+class ParentWithValidation < ActiveRecord::Base
+  has_many :children, :class_name => 'ChildWithValidation'
+  validates :name, :presence => true
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -6,49 +6,49 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :ship_id, :integer
     t.column :ship_type, :string
   end
-  
+
   create_table :parrots, :force => true do |t|
     t.column :name, :string
     t.column :pirate_id, :integer
   end
-  
+
   create_table :mateys, :force => true do |t|
     t.column :name, :string
     t.column :pirate_id, :integer
   end
-  
+
   create_table :treasures, :force => true do |t|
     t.column :found_at, :string
     t.column :owner, :integer
-    t.column :matey_id, :integer    
+    t.column :matey_id, :integer
   end
-  
+
   create_table :gold_pieces, :force => true do |t|
     t.column :treasure_id, :integer
   end
-  
+
   create_table :battle_ships, :force => true do |t|
     t.column :name, :string
-  end  
-  
+  end
+
   create_table :pigs, :force => true do |t|
     t.column :name, :string
     t.column :human_id, :integer
   end
-  
+
   create_table :humen, :force => true do |t|
     t.column :name, :string
   end
-  
+
   create_table :chickens, :force => true do |t|
     t.column :name, :string
-  end  
-  
+  end
+
   create_table :ownerships, :force => true do |t|
     t.column :human_id, :integer
-    t.column :chicken_id, :integer    
+    t.column :chicken_id, :integer
   end
-  
+
   create_table :cars, :force => true do |t|
     t.column :name, :string
   end
@@ -60,6 +60,15 @@ ActiveRecord::Schema.define(:version => 1) do
   create_table :cars_people, :id => false, :force => true do |t|
     t.column :car_id, :integer
     t.column :person_id, :integer
-  end   
-  
+  end
+
+  create_table :parent_with_validations, :force => true do |t|
+    t.column :name, :string
+  end
+
+  create_table :child_with_validations, :force => true do |t|
+    t.column :name, :string
+    t.column :parent_with_validation_id, :integer
+  end
+
 end


### PR DESCRIPTION
Added `validate: false` option to the clone process. This gets passed to AR and forces the entire cloned tree to save without validations. This is useful in cases when you have 1000s of records to clone and are sure of your data integrity. The speed increases are very significant.
