### PR TITLE
Compatibility for ruby 2.0 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,21 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.12)
-      activesupport (= 3.2.12)
+    activemodel (3.2.13.rc1)
+      activesupport (= 3.2.13.rc1)
       builder (~> 3.0.0)
-    activerecord (3.2.12)
-      activemodel (= 3.2.12)
-      activesupport (= 3.2.12)
+    activerecord (3.2.13.rc1)
+      activemodel (= 3.2.13.rc1)
+      activesupport (= 3.2.13.rc1)
       arel (~> 3.0.2)
       tzinfo (~> 0.3.29)
-    activesupport (3.2.12)
-      i18n (~> 0.6)
+    activesupport (3.2.13.rc1)
+      i18n (= 0.6.1)
       multi_json (~> 1.0)
     arel (3.0.2)
     builder (3.0.4)
     git (1.2.5)
-    i18n (0.6.4)
+    i18n (0.6.1)
     jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
@@ -33,6 +33,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (>= 3.1)
+  activerecord (= 3.2.13.rc1)
   jeweler
   sqlite3

--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -3,12 +3,12 @@ class ActiveRecord::Base
     # ActiveRecord::Base has its own dup method for Ruby 1.8.7. We have to
     # redefine it and put it in a module so that we can override it in a
     # module and call the original with super().
-    if !Object.respond_to? :initialize_dup
+    if !Object.respond_to? :initialize_dup, true
       ActiveRecord::Base.class_eval do
         module Dup
           def dup
             copy = super
-            copy.send(:initialize_dup, self)
+            copy.initialize_dup(self)
             copy
           end
         end


### PR DESCRIPTION
fix the error :
`/lib/deep_cloneable.rb:15:in`remove_method': method `dup' not defined in ActiveRecord::Base (NameError)

in the tests.
tests pass on 1.8.7, 1.9.2, 2.0.0 (with rails 3.2.13.rc1)
Change the respond_to? as the rules for respond_to method have changed in ruby 2.0 (http://tenderlovemaking.com/2012/09/07/protected-methods-and-ruby-2-0.html)
