### PR TITLE
Dup fails on model utilizing a "self join" has_many

### DIFF
--- a/test/models.rb
+++ b/test/models.rb
@@ -62,3 +62,7 @@ class ParentWithValidation < ActiveRecord::Base
   has_many :children, :class_name => 'ChildWithValidation'
   validates :name, :presence => true
 end
+
+class Part < ActiveRecord::Base
+  has_many :child_parts, :class_name => 'Part', :foreign_key => 'parent_part_id'
+end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -71,4 +71,9 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :parent_with_validation_id, :integer
   end
 
+  create_table :parts, :force => true do |t|
+    t.column :name, :string
+    t.column :parent_part_id, :integer
+  end
+
 end

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -258,4 +258,14 @@ class TestDeepCloneable < Test::Unit::TestCase
     assert_equal dup_parent.errors.messages, :children => ["is invalid"]
   end
 
+  def test_self_join_has_many
+    parent_part = Part.create(:name => 'Parent')
+    child1 = Part.create(:name => 'Child 1', :parent_part_id => parent_part.id)
+    child2 = Part.create(:name => 'Child 2', :parent_part_id => parent_part.id)
+
+    dup_part = parent_part.dup :include => :child_parts
+    assert dup_part.save
+    assert_equal 2, dup_part.child_parts.size
+  end
+
 end


### PR DESCRIPTION
I'm trying to use deep_cloneable on a model that has a self join has_many. Similar to the following

``` ruby
class Part < ActiveRecord::Base
  has_many :child_parts, :class_name => 'Part', :foreign_key => 'parent_part_id'
end
```

The error is NoMethodError: undefined method `each' at lib/deep_cloneable.rb:122

I'm unsure how to fix it so this pull request is just a failing test demonstrating the bug.

Thanks.
