### PR TITLE
Added HABTM duplication as an option.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -63,6 +63,9 @@ When an object isn't found in the dictionary, it will be populated. By passing i
    
 === Cloning without validations
    pirate.dup :include => {:treasures => :gold_pieces}, :validate => false
+
+=== Cloning objects though `has_and_belongs_to_many` association
+  person.dup :include => :cars, :dup_habtm => true
    
 == Contributors
 

--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -108,8 +108,15 @@ class ActiveRecord::Base
             end
           end
 
+          association_method =
+            if association_reflection.options[:through]
+              "dup_#{association_reflection.macro}_through"
+            else
+              "dup_#{association_reflection.macro}_association"
+            end
+
           cloned_object = send(
-            "dup_#{association_reflection.macro}_#{association_reflection.class.name.demodulize.underscore.gsub('_reflection', '')}", 
+            association_method,
             { :reflection => association_reflection, :association => association, :copy => kopy, :dup_options => dup_options },
             &block
           )

--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -63,13 +63,12 @@ class ActiveRecord::Base
       dict = options[:dictionary]
       dict ||= {} if options.delete(:use_dictionary)
 
-      kopy = if dict
+      kopy = unless dict
+        super()
+      else
         tableized_class = self.class.name.tableize.to_sym
         dict[tableized_class] ||= {}
-        dict[tableized_class][self.id] ||= {}
-        dict[tableized_class][self.id][self] ||= super()
-      else
-        super()
+        dict[tableized_class][self] ||= super()
       end
 
       block.call(self, kopy) if block
@@ -131,34 +130,25 @@ class ActiveRecord::Base
   private
   
     def dup_belongs_to_association options, &block
-      dict = options[:dup_options][:dictionary]
-      foreign_key_name = options[:reflection].foreign_key
-      klass_name = options[:reflection].klass.name.tableize.to_sym
-
-      fetch_from_dictionary(dict, klass_name, self.send(foreign_key_name)) ||
-        (self.send(options[:association]) && self.send(options[:association]).dup(options[:dup_options], &block))
-    end
+      self.send(options[:association]) && self.send(options[:association]).dup(options[:dup_options], &block)
+    end  
   
     def dup_has_one_association options, &block
       dup_belongs_to_association options, &block
     end
     
     def dup_has_many_association options, &block
-      foreign_key_name = options[:reflection].foreign_key.to_s
+      primary_key_name = options[:reflection].foreign_key.to_s
 
       reverse_association_name = options[:reflection].klass.reflect_on_all_associations.detect do |reflection|
-        reflection.foreign_key.to_s == foreign_key_name && reflection != options[:reflection]
+        reflection.foreign_key.to_s == primary_key_name && reflection != options[:reflection]
       end.try(:name)
 
-      dict = options[:dup_options][:dictionary]
-
       self.send(options[:association]).collect do |obj|
-        fetch_from_dictionary(dict, obj.class.name.tableize.to_sym, obj.id) || begin
-          tmp = obj.dup(options[:dup_options], &block)
-          tmp.send("#{foreign_key_name}=", nil)
-          tmp.send("#{reverse_association_name.to_s}=", options[:copy]) if reverse_association_name
-          tmp
-        end
+        tmp = obj.dup(options[:dup_options], &block)
+        tmp.send("#{primary_key_name}=", nil)
+        tmp.send("#{reverse_association_name.to_s}=", options[:copy]) if reverse_association_name
+        tmp
       end      
     end
         
@@ -179,22 +169,14 @@ class ActiveRecord::Base
         (reflection.macro == options[:macro]) && (reflection.association_foreign_key.to_s == options[:primary_key_name])
       end.try(:name)
 
-      dict = options[:dup_options][:dictionary]
-
       self.send(options[:association]).collect do |obj|
-        fetch_from_dictionary(dict, obj.class.name.tableize.to_sym, obj.id) || begin
-          if options[:dup_options][:dup_habtm]
-            obj = obj.dup(options[:dup_options], &block)
-          else
-            obj.send(reverse_association_name).target << options[:copy]
-          end
-          obj
+        if options[:dup_options][:dup_habtm]
+          obj = obj.dup(options[:dup_options], &block)
+        else
+          obj.send(reverse_association_name).target << options[:copy]
         end
+        obj
       end
-    end
-
-    def fetch_from_dictionary(dict, klass, id)
-      dict && dict[klass] && dict[klass][id] && dict[klass][id].values.first
     end
     
     class AssociationNotFoundException < StandardError; end


### PR DESCRIPTION
Deep_cloneable doesn't dup HABTM associated objects, only the associations themselves.

This patch introduces an option `:dup_habtm`, which if set to true simply calls `dup` on all the associated objects, too. It doesn't do the reverse association that it normally does because that will generate two join records in the join table when you save the dupped object.

```
# without :dup_habtm (same as before)
s = Student.first.dup include: :klasses
s.klasses.any?(&:new_record?)
=> false

# with :dup_habtm
s = Student.first.dup include: :klasses, dup_habtm: true
s.klasses.all?(&:new_record?)
=> true
```

Added a test for this option. All tests pass in my Ruby 2.0.0 environment.

I needed this so thought it might be useful for others, too.
