### PR TITLE
Resolve dependencies conflicts with activerecord v 3.2+

### DIFF
--- a/deep_cloneable.gemspec
+++ b/deep_cloneable.gemspec
@@ -50,12 +50,12 @@ Gem::Specification.new do |s|
     s.specification_version = 4
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<activerecord>, ["~> 3.1.0"])
+      s.add_runtime_dependency(%q<activerecord>, [">= 3.1.0"])
     else
-      s.add_dependency(%q<activerecord>, ["~> 3.1.0"])
+      s.add_dependency(%q<activerecord>, [">= 3.1.0"])
     end
   else
-    s.add_dependency(%q<activerecord>, ["~> 3.1.0"])
+    s.add_dependency(%q<activerecord>, [">= 3.1.0"])
   end
 end
 


### PR DESCRIPTION
`activerecord, ~> 3.1.0` is equal to `>=3.1.0 and < 3.2`, according to [documentation](http://docs.rubygems.org/read/chapter/16#page74) thus having activerecord v 3.2+ causes the issue. Hope it will be merged soon so we could switch back to original source.
