### PR TITLE
Change #dup to #deep_clone

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,57 +21,57 @@ This gem gives every ActiveRecord::Base object the possibility to do a deep clon
 == Example
 
 === Cloning one single association
-   pirate.dup :include => :mateys
+   pirate.deep_clone :include => :mateys
 
 === Cloning multiple associations
-   pirate.dup :include => [:mateys, :treasures]
+   pirate.deep_clone :include => [:mateys, :treasures]
 
 === Cloning really deep
-   pirate.dup :include => {:treasures => :gold_pieces}
+   pirate.deep_clone :include => {:treasures => :gold_pieces}
 
 === Cloning really deep with multiple associations
-   pirate.dup :include => [:mateys, {:treasures => :gold_pieces}]
+   pirate.deep_clone :include => [:mateys, {:treasures => :gold_pieces}]
 
 === Cloning really deep with multiple associations and a dictionary
 
 A dictionary ensures that models are not cloned multiple times when it is associated to nested models.
 When using a dictionary, ensure recurring associations are cloned first:
 
-  pirate.dup :include => [:mateys, {:treasures => [:matey, :gold_pieces]}], :use_dictionary => true
+  pirate.deep_clone :include => [:mateys, {:treasures => [:matey, :gold_pieces]}], :use_dictionary => true
 
 If this is not an option for you, it is also possible to populate the dictionary manually in advance:
 
   dict = { :mateys => {} }
-  pirate.mateys.each{|m| dict[:mateys][m] = m.dup }
-  pirate.dup :include => [:mateys, {:treasures => [:matey, :gold_pieces]}], :dictionary => dict
+  pirate.mateys.each{|m| dict[:mateys][m] = m.deep_clone }
+  pirate.deep_clone :include => [:mateys, {:treasures => [:matey, :gold_pieces]}], :dictionary => dict
 
-When an object isn't found in the dictionary, it will be populated. By passing in an empty dictionary you can populate it automatically and reuse it in subsequent dups to avoid creating multiples of the same object where you have overlapping associations.
+When an object isn't found in the dictionary, it will be populated. By passing in an empty dictionary you can populate it automatically and reuse it in subsequent deep_clones to avoid creating multiples of the same object where you have overlapping associations.
 
 === Cloning a model without an attribute
-   pirate.dup :except => :name
+   pirate.deep_clone :except => :name
 
 === Cloning a model without multiple attributes
-   pirate.dup :except => [:name, :nick_name]
+   pirate.deep_clone :except => [:name, :nick_name]
 
 === Cloning a model without an attribute or nested multiple attributes
-   pirate.dup :include => :parrot, :except => [:name, { :parrot => [:name] }]
+   pirate.deep_clone :include => :parrot, :except => [:name, { :parrot => [:name] }]
 
 === Cloning with a block
-   pirate.dup :include => :parrot do |original, kopy|
+   pirate.deep_clone :include => :parrot do |original, kopy|
      kopy.cloned_from_id = original.id if kopy.respond_to?(:cloned_from_id)
    end
 
 === Cloning without validations
-   pirate.dup :include => {:treasures => :gold_pieces}, :validate => false
+   pirate.deep_clone :include => {:treasures => :gold_pieces}, :validate => false
 
 === Cloning a model with only explicitly assigned attribute
-   pirate.dup :only => :name
+   pirate.deep_clone :only => :name
 
 === Cloning a model with only multiple explicitly assigned attributes
-   pirate.dup :only => [:name, :nick_name]
+   pirate.deep_clone :only => [:name, :nick_name]
 
 === Cloning a model with explicitly assigned attributes or nested multiple attributes
-   pirate.dup :include => :parrot, :only => [:name, { :parrot => [:name] }]
+   pirate.deep_clone :include => :parrot, :only => [:name, { :parrot => [:name] }]
 
 == Note on Patches/Pull Requests
 

--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -17,18 +17,18 @@ class ActiveRecord::Base
     end
 
     # Deep dups an ActiveRecord model. See README.rdoc
-    def dup *args, &block
+    def deep_clone *args, &block
       options = args[0] || {}
 
       dict = options[:dictionary]
       dict ||= {} if options.delete(:use_dictionary)
 
       kopy = unless dict
-        super()
+        dup()
       else
         tableized_class = self.class.name.tableize.to_sym
         dict[tableized_class] ||= {}
-        dict[tableized_class][self] ||= super()
+        dict[tableized_class][self] ||= dup()
       end
 
       block.call(self, kopy) if block
@@ -94,7 +94,7 @@ class ActiveRecord::Base
   private
 
     def dup_belongs_to_association options, &block
-      self.send(options[:association]) && self.send(options[:association]).dup(options[:dup_options], &block)
+      self.send(options[:association]) && self.send(options[:association]).deep_clone(options[:dup_options], &block)
     end
 
     def dup_has_one_association options, &block
@@ -109,7 +109,7 @@ class ActiveRecord::Base
       end.try(:name)
 
       self.send(options[:association]).collect do |obj|
-        tmp = obj.dup(options[:dup_options], &block)
+        tmp = obj.deep_clone(options[:dup_options], &block)
         tmp.send("#{primary_key_name}=", nil)
         tmp.send("#{reverse_association_name.to_s}=", options[:copy]) if reverse_association_name
         tmp

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -11,155 +11,155 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     @ship = BattleShip.create(:name => 'Black Pearl', :pirates => [@jack])
   end
 
-  def test_single_dup_exception
-    dup = @jack.dup(:except => :name)
-    assert dup.new_record?
-    assert dup.save
-    assert_equal @jack.name, @jack.dup.name
-    assert_nil dup.name
-    assert_equal @jack.nick_name, dup.nick_name
+  def test_single_deep_clone_exception
+    deep_clone = @jack.deep_clone(:except => :name)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal @jack.name, @jack.deep_clone.name
+    assert_nil deep_clone.name
+    assert_equal @jack.nick_name, deep_clone.nick_name
   end
 
-  def test_multiple_dup_exception
-    dup = @jack.dup(:except => [:name, :nick_name])
-    assert dup.new_record?
-    assert dup.save
-    assert_nil dup.name
-    assert_equal 'no nickname', dup.nick_name
-    assert_equal @jack.age, dup.age
+  def test_multiple_deep_clone_exception
+    deep_clone = @jack.deep_clone(:except => [:name, :nick_name])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_nil deep_clone.name
+    assert_equal 'no nickname', deep_clone.nick_name
+    assert_equal @jack.age, deep_clone.age
   end
 
-  def test_single_dup_onliness
-    dup = @jack.dup(:only => :name)
-    assert dup.new_record?
-    assert dup.save
-    assert_equal @jack.name, dup.name
-    assert_equal 'no nickname', dup.nick_name
-    assert_nil dup.age
-    assert_nil dup.ship_id
-    assert_nil dup.ship_type
+  def test_single_deep_clone_onliness
+    deep_clone = @jack.deep_clone(:only => :name)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal @jack.name, deep_clone.name
+    assert_equal 'no nickname', deep_clone.nick_name
+    assert_nil deep_clone.age
+    assert_nil deep_clone.ship_id
+    assert_nil deep_clone.ship_type
   end
 
-  def test_multiple_dup_onliness
-    dup = @jack.dup(:only => [:name, :nick_name])
-    assert dup.new_record?
-    assert dup.save
-    assert_equal @jack.name, dup.name
-    assert_equal @jack.nick_name, dup.nick_name
-    assert_nil dup.age
-    assert_nil dup.ship_id
-    assert_nil dup.ship_type
+  def test_multiple_deep_clone_onliness
+    deep_clone = @jack.deep_clone(:only => [:name, :nick_name])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal @jack.name, deep_clone.name
+    assert_equal @jack.nick_name, deep_clone.nick_name
+    assert_nil deep_clone.age
+    assert_nil deep_clone.ship_id
+    assert_nil deep_clone.ship_type
   end
 
   def test_single_include_association
-    dup = @jack.dup(:include => :mateys)
-    assert dup.new_record?
-    assert dup.save
-    assert_equal 1, dup.mateys.size
+    deep_clone = @jack.deep_clone(:include => :mateys)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.mateys.size
   end
 
   def test_single_include_belongs_to_polymorphic_association
-    dup = @jack.dup(:include => :ship)
-    assert dup.new_record?
-    assert dup.save
-    refute_nil dup.ship
-    refute_equal @jack.ship, dup.ship
+    deep_clone = @jack.deep_clone(:include => :ship)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    refute_nil deep_clone.ship
+    refute_equal @jack.ship, deep_clone.ship
   end
 
   def test_single_include_has_many_polymorphic_association
-    dup = @ship.dup(:include => :pirates)
-    assert dup.new_record?
-    assert dup.save
-    assert dup.pirates.any?
+    deep_clone = @ship.deep_clone(:include => :pirates)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert deep_clone.pirates.any?
   end
 
   def test_multiple_include_association
-    dup = @jack.dup(:include => [:mateys, :treasures])
-    assert dup.new_record?
-    assert dup.save
-    assert_equal 1, dup.mateys.size
-    assert_equal 1, dup.treasures.size
+    deep_clone = @jack.deep_clone(:include => [:mateys, :treasures])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.mateys.size
+    assert_equal 1, deep_clone.treasures.size
   end
 
   def test_deep_include_association
-    dup = @jack.dup(:include => {:treasures => :gold_pieces})
-    assert dup.new_record?
-    assert dup.save
-    assert_equal 1, dup.treasures.size
-    assert_equal 1, dup.gold_pieces.size
+    deep_clone = @jack.deep_clone(:include => {:treasures => :gold_pieces})
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.treasures.size
+    assert_equal 1, deep_clone.gold_pieces.size
   end
 
   def test_include_association_assignments
-    dup = @jack.dup(:include => :treasures)
-    assert dup.new_record?
+    deep_clone = @jack.deep_clone(:include => :treasures)
+    assert deep_clone.new_record?
 
-    dup.treasures.each do |treasure|
-      assert_equal dup, treasure.pirate
+    deep_clone.treasures.each do |treasure|
+      assert_equal deep_clone, treasure.pirate
     end
   end
 
   def test_multiple_and_deep_include_association
-    dup = @jack.dup(:include => {:treasures => :gold_pieces, :mateys => {}})
-    assert dup.new_record?
-    assert dup.save
-    assert_equal 1, dup.treasures.size
-    assert_equal 1, dup.gold_pieces.size
-    assert_equal 1, dup.mateys.size
+    deep_clone = @jack.deep_clone(:include => {:treasures => :gold_pieces, :mateys => {}})
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.treasures.size
+    assert_equal 1, deep_clone.gold_pieces.size
+    assert_equal 1, deep_clone.mateys.size
   end
 
   def test_multiple_and_deep_include_association_with_array
-    dup = @jack.dup(:include => [{:treasures => :gold_pieces}, :mateys])
-    assert dup.new_record?
-    assert dup.save
-    assert_equal 1, dup.treasures.size
-    assert_equal 1, dup.gold_pieces.size
-    assert_equal 1, dup.mateys.size
+    deep_clone = @jack.deep_clone(:include => [{:treasures => :gold_pieces}, :mateys])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.treasures.size
+    assert_equal 1, deep_clone.gold_pieces.size
+    assert_equal 1, deep_clone.mateys.size
   end
 
   def test_with_belongs_to_relation
-    dup = @jack.dup(:include => :parrot)
-    assert dup.new_record?
-    assert dup.save
-    refute_equal dup.parrot, @jack.parrot
+    deep_clone = @jack.deep_clone(:include => :parrot)
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    refute_equal deep_clone.parrot, @jack.parrot
   end
 
   def test_should_pass_nested_exceptions
-    dup = @jack.dup(:include => :parrot, :except => [:name, { :parrot => [:name] }])
-    assert dup.new_record?
-    assert dup.save
-    refute_equal dup.parrot, @jack.parrot
-    assert_equal dup.parrot.age, @jack.parrot.age
+    deep_clone = @jack.deep_clone(:include => :parrot, :except => [:name, { :parrot => [:name] }])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    refute_equal deep_clone.parrot, @jack.parrot
+    assert_equal deep_clone.parrot.age, @jack.parrot.age
     refute_nil @jack.parrot.name
-    assert_nil dup.parrot.name
+    assert_nil deep_clone.parrot.name
   end
 
   def test_should_pass_nested_onlinesses
-    dup = @jack.dup(:include => :parrot, :only => [:name, { :parrot => [:name] }])
-    assert dup.new_record?
-    assert dup.save
-    refute_equal dup.parrot, @jack.parrot
-    assert_equal dup.parrot.name, @jack.parrot.name
-    assert_nil dup.parrot.age
+    deep_clone = @jack.deep_clone(:include => :parrot, :only => [:name, { :parrot => [:name] }])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    refute_equal deep_clone.parrot, @jack.parrot
+    assert_equal deep_clone.parrot.name, @jack.parrot.name
+    assert_nil deep_clone.parrot.age
   end
 
-  def test_should_not_double_dup_when_using_dictionary
+  def test_should_not_double_deep_clone_when_using_dictionary
     current_matey_count = Matey.count
-    dup = @jack.dup(:include => [:mateys, { :treasures => :matey }], :use_dictionary => true)
-    assert dup.new_record?
-    dup.save!
+    deep_clone = @jack.deep_clone(:include => [:mateys, { :treasures => :matey }], :use_dictionary => true)
+    assert deep_clone.new_record?
+    deep_clone.save!
 
     assert_equal current_matey_count + 1, Matey.count
   end
 
-  def test_should_not_double_dup_when_using_manual_dictionary
+  def test_should_not_double_deep_clone_when_using_manual_dictionary
     current_matey_count = Matey.count
 
     dict = { :mateys => {} }
-    @jack.mateys.each{|m| dict[:mateys][m] = m.dup }
+    @jack.mateys.each{|m| dict[:mateys][m] = m.deep_clone }
 
-    dup = @jack.dup(:include => [:mateys, { :treasures => :matey }], :dictionary => dict)
-    assert dup.new_record?
-    dup.save!
+    deep_clone = @jack.deep_clone(:include => [:mateys, { :treasures => :matey }], :dictionary => dict)
+    assert deep_clone.new_record?
+    deep_clone.save!
 
     assert_equal current_matey_count + 1, Matey.count
   end
@@ -168,21 +168,21 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     @human = Animal::Human.create :name => "Michael"
     @pig = Animal::Pig.create :human => @human, :name => 'big pig'
 
-    dup_human = @human.dup(:include => [:pigs])
-    assert dup_human.new_record?
-    assert dup_human.save
-    assert_equal 1, dup_human.pigs.count
+    deep_clone_human = @human.deep_clone(:include => [:pigs])
+    assert deep_clone_human.new_record?
+    assert deep_clone_human.save
+    assert_equal 1, deep_clone_human.pigs.count
 
     @human2 = Animal::Human.create :name => "John"
     @pig2 = @human2.pigs.create :name => 'small pig'
 
-    dup_human_2 = @human.dup(:include => [:pigs])
-    assert dup_human_2.new_record?
-    assert dup_human_2.save
-    assert_equal 1, dup_human_2.pigs.count
+    deep_clone_human_2 = @human.deep_clone(:include => [:pigs])
+    assert deep_clone_human_2.new_record?
+    assert deep_clone_human_2.save
+    assert_equal 1, deep_clone_human_2.pigs.count
   end
 
-  def test_should_dup_many_to_many_associations
+  def test_should_deep_clone_many_to_many_associations
     @human = Animal::Human.create :name => "Michael"
     @human2 = Animal::Human.create :name => "Jack"
     @chicken1 = Animal::Chicken.create :name => 'Chick1'
@@ -190,24 +190,24 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     @human.chickens << [@chicken1, @chicken2]
     @human2.chickens << [@chicken1, @chicken2]
 
-    dup_human = @human.dup(:include => :ownerships)
-    assert dup_human.new_record?
-    assert dup_human.save
-    assert_equal 2, dup_human.chickens.count
+    deep_clone_human = @human.deep_clone(:include => :ownerships)
+    assert deep_clone_human.new_record?
+    assert deep_clone_human.save
+    assert_equal 2, deep_clone_human.chickens.count
   end
 
-  def test_should_dup_with_block
-    dup = @jack.dup(:include => :parrot) do |original, kopy|
+  def test_should_deep_clone_with_block
+    deep_clone = @jack.deep_clone(:include => :parrot) do |original, kopy|
       kopy.cloned_from_id = original.id
     end
 
-    assert dup.new_record?
-    assert dup.save
-    assert_equal @jack.id, dup.cloned_from_id
-    assert_equal @jack.parrot.id, dup.parrot.cloned_from_id
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal @jack.id, deep_clone.cloned_from_id
+    assert_equal @jack.parrot.id, deep_clone.parrot.cloned_from_id
   end
 
-  def test_should_dup_habtm_associations
+  def test_should_deep_clone_habtm_associations
     @person1 = Person.create :name => "Bill"
     @person2 = Person.create :name => "Ted"
     @car1 = Car.create :name => 'Mustang'
@@ -215,42 +215,42 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     @person1.cars << [@car1, @car2]
     @person2.cars << [@car1, @car2]
 
-    dup_person = @person1.dup :include => :cars
+    deep_clone_person = @person1.deep_clone :include => :cars
 
-    assert dup_person.new_record?
-    assert_equal [@person1, @person2, dup_person], @car1.people
-    assert_equal [@person1, @person2, dup_person], @car2.people
+    assert deep_clone_person.new_record?
+    assert_equal [@person1, @person2, deep_clone_person], @car1.people
+    assert_equal [@person1, @person2, deep_clone_person], @car2.people
 
-    assert dup_person.save
+    assert deep_clone_person.save
 
-    # did NOT dup the Car instances
+    # did NOT deep_clone the Car instances
     assert_equal 2, Car.all.count
 
-    # did dup the correct join table rows
-    assert_equal @person1.cars, dup_person.cars
-    assert_equal 2, dup_person.cars.count
+    # did deep_clone the correct join table rows
+    assert_equal @person1.cars, deep_clone_person.cars
+    assert_equal 2, deep_clone_person.cars.count
   end
 
-  def test_should_dup_habtm_associations_with_missing_reverse_association
+  def test_should_deep_clone_habtm_associations_with_missing_reverse_association
     @coin = Coin.create :value => 1
     @person = Person.create :name => "Bill"
     @coin.people << @person
 
-    dup = @coin.dup :include => :people
-    assert dup.new_record?
+    deep_clone = @coin.deep_clone :include => :people
+    assert deep_clone.new_record?
     assert_equal [@person], @coin.people
-    assert dup.save
+    assert deep_clone.save
   end
 
-  def test_should_dup_joined_association
+  def test_should_deep_clone_joined_association
     subject1 = Subject.create(:name => 'subject 1')
     subject2 = Subject.create(:name => 'subject 2')
     student = Student.create(:name => 'Parent', :subjects => [subject1, subject2])
 
-    dup = student.dup :include => { :student_assignments => :subject }
-    dup.save # Subjects will have been set after save
-    assert_equal 2, dup.subjects.size
-    [subject1, subject2].each{|subject| assert !dup.subjects.include?(subject) }
+    deep_clone = student.deep_clone :include => { :student_assignments => :subject }
+    deep_clone.save # Subjects will have been set after save
+    assert_equal 2, deep_clone.subjects.size
+    [subject1, subject2].each{|subject| assert !deep_clone.subjects.include?(subject) }
   end
 
   def test_parent_validations_run_on_save_after_clone
@@ -258,13 +258,13 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     parent = ParentWithValidation.new :children => [child]
     parent.save :validate => false
 
-    dup_parent = parent.dup :include => :children
+    deep_clone_parent = parent.deep_clone :include => :children
 
-    assert !dup_parent.save
-    assert dup_parent.new_record?
-    assert !dup_parent.valid?
-    assert dup_parent.children.first.valid?
-    assert_equal dup_parent.errors.messages, :name => ["can't be blank"]
+    assert !deep_clone_parent.save
+    assert deep_clone_parent.new_record?
+    assert !deep_clone_parent.valid?
+    assert deep_clone_parent.children.first.valid?
+    assert_equal deep_clone_parent.errors.messages, :name => ["can't be blank"]
   end
 
   def test_parent_validations_dont_run_on_save_after_clone
@@ -272,13 +272,13 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     parent = ParentWithValidation.new :children => [child]
     parent.save :validate => false
 
-    dup_parent = parent.dup :include => :children, :validate => false
+    deep_clone_parent = parent.deep_clone :include => :children, :validate => false
 
-    assert dup_parent.save
-    assert !dup_parent.new_record?
-    assert !dup_parent.valid?
-    assert dup_parent.children.first.valid?
-    assert_equal dup_parent.errors.messages, :name => ["can't be blank"]
+    assert deep_clone_parent.save
+    assert !deep_clone_parent.new_record?
+    assert !deep_clone_parent.valid?
+    assert deep_clone_parent.children.first.valid?
+    assert_equal deep_clone_parent.errors.messages, :name => ["can't be blank"]
   end
 
   def test_child_validations_run_on_save_after_clone
@@ -286,13 +286,13 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     child.save :validate => false
     parent = ParentWithValidation.create :name => 'John', :children => [child]
 
-    dup_parent = parent.dup :include => :children
+    deep_clone_parent = parent.deep_clone :include => :children
 
-    assert !dup_parent.save
-    assert dup_parent.new_record?
-    assert !dup_parent.valid?
-    assert !dup_parent.children.first.valid?
-    assert_equal dup_parent.errors.messages, :children => ["is invalid"]
+    assert !deep_clone_parent.save
+    assert deep_clone_parent.new_record?
+    assert !deep_clone_parent.valid?
+    assert !deep_clone_parent.children.first.valid?
+    assert_equal deep_clone_parent.errors.messages, :children => ["is invalid"]
   end
 
   def test_child_validations_run_on_save_after_clone
@@ -300,13 +300,13 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     child.save :validate => false
     parent = ParentWithValidation.create :name => 'John', :children => [child]
 
-    dup_parent = parent.dup :include => :children, :validate => false
+    deep_clone_parent = parent.deep_clone :include => :children, :validate => false
 
-    assert dup_parent.save
-    assert !dup_parent.new_record?
-    assert !dup_parent.valid?
-    assert !dup_parent.children.first.valid?
-    assert_equal dup_parent.errors.messages, :children => ["is invalid"]
+    assert deep_clone_parent.save
+    assert !deep_clone_parent.new_record?
+    assert !deep_clone_parent.valid?
+    assert !deep_clone_parent.children.first.valid?
+    assert_equal deep_clone_parent.errors.messages, :children => ["is invalid"]
   end
 
   def test_self_join_has_many
@@ -314,9 +314,9 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     child1 = Part.create(:name => 'Child 1', :parent_part_id => parent_part.id)
     child2 = Part.create(:name => 'Child 2', :parent_part_id => parent_part.id)
 
-    dup_part = parent_part.dup :include => :child_parts
-    assert dup_part.save
-    assert_equal 2, dup_part.child_parts.size
+    deep_clone_part = parent_part.deep_clone :include => :child_parts
+    assert deep_clone_part.save
+    assert_equal 2, deep_clone_part.child_parts.size
   end
 
   def test_should_include_has_many_through_associations
@@ -324,19 +324,19 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     subject2 = Subject.create(:name => 'subject 2')
     student = Student.create(:name => 'Parent', :subjects => [subject1, subject2])
 
-    dup = student.dup :include => :subjects
-    assert_equal 2, dup.subjects.size
-    assert_equal [[student, dup],[student, dup]], dup.subjects.map{|subject| subject.students }
+    deep_clone = student.deep_clone :include => :subjects
+    assert_equal 2, deep_clone.subjects.size
+    assert_equal [[student, deep_clone],[student, deep_clone]], deep_clone.subjects.map{|subject| subject.students }
   end
 
-  def test_should_dup_unsaved_objects
+  def test_should_deep_clone_unsaved_objects
     jack = Pirate.new(:name => 'Jack Sparrow', :nick_name => 'Captain Jack', :age => 30)
     jack.mateys.build(:name => 'John')
 
-    dup = jack.dup(:include => :mateys)
-    assert dup.new_record?
-    assert_equal 1, dup.mateys.size
-    assert_equal 'John', dup.mateys.first.name
+    deep_clone = jack.deep_clone(:include => :mateys)
+    assert deep_clone.new_record?
+    assert_equal 1, deep_clone.mateys.size
+    assert_equal 'John', deep_clone.mateys.first.name
   end
 
 end


### PR DESCRIPTION
This changes the dup method from #dup to #deep_clone as suggested in https://github.com/moiristo/deep_cloneable/issues/24 by @unixmonkey

WARNING!!! This is potentially a backwards incompatible commit, as it changes the api for the object. I'm wondering if this belongs somehow on a different branch.

Tests are all passing, no changes to actual content of the tests, just the method used.

I've updated some of the docs but I imagine there are parts that need to be updated beyond what I've done.

This avoids the issue with incompatible gems such as friendly id. https://github.com/norman/friendly_id/blob/master/lib/friendly_id/base.rb#L255
