### PR TITLE
Check the dictionary before cloning a habtm or has many through

### DIFF
--- a/test/models.rb
+++ b/test/models.rb
@@ -86,3 +86,18 @@ class StudentAssignment < ActiveRecord::Base
   belongs_to :subject
   belongs_to :student
 end
+
+class Building < ActiveRecord::Base
+  has_many :apartments
+  has_many :contractors
+end
+
+class Apartment < ActiveRecord::Base
+  belongs_to :building
+  has_and_belongs_to_many :contractors
+end
+
+class Contractor < ActiveRecord::Base
+  belongs_to :building
+  has_and_belongs_to_many :apartments
+end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -98,4 +98,23 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :student_id, :integer
     t.column :subject_id, :integer
   end
+
+  create_table :buildings, :force => true do |t|
+    t.column :name, :string
+  end
+
+  create_table :apartments, :force => true do |t|
+    t.column :number, :string
+    t.column :building_id, :integer
+  end
+
+  create_table :contractors, :force => true do |t|
+    t.column :name, :string
+    t.column :building_id, :integer
+  end
+
+  create_table :apartments_contractors, :force => true do |t|
+    t.column :apartment_id, :integer
+    t.column :contractor_id, :integer
+  end
 end

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -361,4 +361,28 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
 
   end
 
+  def test_should_find_in_dict_for_habtm
+    apt = Apartment.create(:number => "101")
+    contractor = Contractor.create(:name => "contractor", :apartments => [apt])
+
+    apt.contractors = [contractor]
+    apt.save!
+
+    building = Building.create(:name => "Tall Building", :contractors => [contractor], :apartments => [apt])
+
+    deep_clone = building.deep_clone(:include => [
+      :apartments,
+      {
+        :contractors => [
+          :apartments
+        ]
+      }
+    ],
+    :use_dictionary => true
+                                    )
+    deep_clone.save!
+  
+    assert_equal deep_clone.contractors.first.apartments.first.id, deep_clone.apartments.first.id
+    assert_equal deep_clone.apartments.first.contractors.first.id, deep_clone.contractors.first.id
+  end
 end


### PR DESCRIPTION
`deep_cloneable` doesn't dup HABTM associated objects, only the associations themselves.

This patch introduces logic to check the dictionary for an existing clone.  This way if two classes joined by a HABTM (or `has_many :through`) are deep_cloned via a shared parent, they won't be unnecessarily duplicated.

I couldn't think of a situation in which you wouldn't want to check the dictionary, so I figured it would be best to make it the default behavior rather than passing in an option, but that's a possibility as well.

I have added a test to illustrate the use case.  