### PR TITLE
Test / Documentation for cloning associations with conditionals

### DIFF
--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -361,6 +361,20 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
 
   end
 
+  def test_should_reject_copies_if_conditionals_are_passed_with_associations
+    deep_clone = @ship.deep_clone(:include => [:pirates => {:treasures => [], :mateys => [], :unless => lambda {|pirate| pirate.name == 'Jack Sparrow'}}])
+
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 0, deep_clone.pirates.size
+
+    deep_clone = @ship.deep_clone(:include => [:pirates => {:treasures => [], :mateys => [], :if => lambda {|pirate| pirate.name == 'Jack Sparrow'}}])
+    assert deep_clone.new_record?
+    assert deep_clone.save
+    assert_equal 1, deep_clone.pirates.size
+  end
+
+
   def test_should_find_in_dict_for_habtm
     apt = Apartment.create(:number => "101")
     contractor = Contractor.create(:name => "contractor", :apartments => [apt])


### PR DESCRIPTION
It took me a long time to figure out the syntax for cloning associations with conditionals, so I wrote a test.  Previously, I was using the array syntax for associations, but adding conditions required to switching to a hash syntax and I could not figure out what the right hand side of the hash.  An empty array worked and I wrote a test for it.

Previously, I was cloning like this:

    @ship.deep_clone(:include => [:pirates => [:treasures, :mateys]])

But then I needed conditionals on the pirates so the pirates associations array becomes a hash like this:

    @ship.deep_clone(:include => [:pirates => {:treasures => [], :mateys => []}])

and then the conditional can be added.

This test really just documents how you add conditionals to array based cloning.

