### PR TITLE
Support serialized defaults

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -20,7 +20,7 @@ class ActiveRecord::Base
       if options[:except]
         exceptions = options[:except].nil? ? [] : [options[:except]].flatten
         exceptions.each do |attribute|
-          kopy.send(:write_attribute, attribute, self.class.column_defaults.dup[attribute.to_s]) unless attribute.kind_of?(Hash)
+          dup_default_attribute_value_to(kopy, attribute, self) unless attribute.kind_of?(Hash)
         end
         deep_exceptions = exceptions.select{|e| e.kind_of?(Hash) }.inject({}){|m,h| m.merge(h) }
       end
@@ -31,7 +31,7 @@ class ActiveRecord::Base
         object_attrs = kopy.attributes.keys.collect{ |s| s.to_sym }
         exceptions = object_attrs - onlinesses
         exceptions.each do |attribute|
-          kopy.send(:write_attribute, attribute, self.class.column_defaults.dup[attribute.to_s]) unless attribute.kind_of?(Hash)
+          dup_default_attribute_value_to(kopy, attribute, self) unless attribute.kind_of?(Hash)
         end
         deep_onlinesses = onlinesses.select{|e| e.kind_of?(Hash) }.inject({}){|m,h| m.merge(h) }
       end
@@ -96,6 +96,10 @@ class ActiveRecord::Base
     end
 
   private
+
+    def dup_default_attribute_value_to(kopy, attribute, origin)
+      kopy.send(:raw_write_attribute, attribute, origin.class.column_defaults.dup[attribute.to_s])
+    end
 
     def dup_belongs_to_association options, &block
       object = self.send(options[:association])

--- a/test/database.yml
+++ b/test/database.yml
@@ -1,6 +1,6 @@
 sqlite: 
-  adapter: sqlite 
+  adapter: sqlite
   database: ":memory:"
-sqlite3: 
-  adapter: sqlite3 
+sqlite3:
+  adapter: sqlite3
   database: ":memory:"

--- a/test/models.rb
+++ b/test/models.rb
@@ -36,7 +36,7 @@ class Pirate < ActiveRecord::Base
   has_many :gold_pieces, :through => :treasures
   has_one :parrot
 
-  serialize :piastres #, Array
+  serialize :piastres, Array
 
   attr_accessor :cloned_from_id
 end

--- a/test/models.rb
+++ b/test/models.rb
@@ -36,6 +36,8 @@ class Pirate < ActiveRecord::Base
   has_many :gold_pieces, :through => :treasures
   has_one :parrot
 
+  serialize :piastres #, Array
+
   attr_accessor :cloned_from_id
 end
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -5,6 +5,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :age, :string
     t.column :ship_id, :integer
     t.column :ship_type, :string
+    t.column :piastres, :text, :default => [].to_yaml
   end
 
   create_table :parrots, :force => true do |t|

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -32,6 +32,7 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
   def test_single_deep_clone_onliness
     deep_clone = @jack.deep_clone(:only => :name)
     assert deep_clone.new_record?
+    assert deep_clone.piastres, []
     assert deep_clone.save
     assert_equal @jack.name, deep_clone.name
     assert_equal 'no nickname', deep_clone.nick_name
@@ -43,6 +44,7 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
   def test_multiple_deep_clone_onliness
     deep_clone = @jack.deep_clone(:only => [:name, :nick_name])
     assert deep_clone.new_record?
+    assert deep_clone.piastres, []
     assert deep_clone.save
     assert_equal @jack.name, deep_clone.name
     assert_equal @jack.nick_name, deep_clone.nick_name
@@ -136,6 +138,7 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
   def test_should_pass_nested_onlinesses
     deep_clone = @jack.deep_clone(:include => :parrot, :only => [:name, { :parrot => [:name] }])
     assert deep_clone.new_record?
+    assert deep_clone.piastres, []
     assert deep_clone.save
     refute_equal deep_clone.parrot, @jack.parrot
     assert_equal deep_clone.parrot.name, @jack.parrot.name


### PR DESCRIPTION
Sometimes it is useful to set default serialized attributes in db level. Rails caches this nicely, but deep clone fails. This is bugfix.