### PR TITLE
add ruby 2.2.x and 2.3.0 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.5
+  - 2.1
+  - 2.2
+  - 2.3.0
 
 gemfile:
   - gemfiles/3.1.gemfile
@@ -26,3 +28,7 @@ matrix:
       gemfile: gemfiles/4.1.gemfile
     - rvm: 1.9.2
       gemfile: gemfiles/4.2.gemfile
+    - rvm: 2.2
+      gemfile: gemfiles/3.1.gemfile
+    - rvm: 2.3.0
+      gemfile: gemfiles/3.1.gemfile


### PR DESCRIPTION
By not including  the patch number, Travis will use the latest version of 2.1.x and 2.2.x.  Not sure why that doesn't work for 2.3.x (maybe because there is only one 2.3 release so far)