### PR TITLE
Added require for active_record

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -1,3 +1,5 @@
+require "active_record"
+
 class ActiveRecord::Base
   module DeepCloneable
 


### PR DESCRIPTION
When we tried to use sidekiqswarm, which does a `Bundler.require(:default)`, this gem was not happy that the ActiveRecord constant was not yet defined.  Adding the require fixes that.