### PR TITLE
Use inverse_of if it's defined for finding reverse migration

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -116,9 +116,13 @@ class ActiveRecord::Base
     def dup_has_many_association options, &block
       primary_key_name = options[:reflection].foreign_key.to_s
 
-      reverse_association_name = options[:reflection].klass.reflect_on_all_associations.detect do |reflection|
-        reflection.foreign_key.to_s == primary_key_name && reflection != options[:reflection]
-      end.try(:name)
+      if options[:reflection].inverse_of.present?
+        reverse_association_name = options[:reflection].inverse_of.name
+      else
+        reverse_association_name = options[:reflection].klass.reflect_on_all_associations.detect do |reflection|
+          reflection.foreign_key.to_s == primary_key_name && reflection != options[:reflection]
+        end.try(:name)
+      end
 
       objects = self.send(options[:association])
       objects = objects.select{|object| evaluate_conditions(object, options[:conditions]) } if options[:conditions].any?
@@ -144,9 +148,13 @@ class ActiveRecord::Base
     end
 
     def dup_join_association options, &block
-      reverse_association_name = options[:reflection].klass.reflect_on_all_associations.detect do |reflection|
-        (reflection.macro == options[:macro]) && (reflection.association_foreign_key.to_s == options[:primary_key_name])
-      end.try(:name)
+      if options[:reflection].inverse_of.present?
+        reverse_association_name = options[:reflection].inverse_of.name
+      else
+        reverse_association_name = options[:reflection].klass.reflect_on_all_associations.detect do |reflection|
+          (reflection.macro == options[:macro]) && (reflection.association_foreign_key.to_s == options[:primary_key_name])
+        end.try(:name)
+      end
 
       objects = self.send(options[:association])
       objects = objects.select{|object| evaluate_conditions(object, options[:conditions]) } if options[:conditions].any?

--- a/test/models.rb
+++ b/test/models.rb
@@ -25,8 +25,18 @@ end
 
 class GoldPiece < ActiveRecord::Base;   belongs_to :treasure  end
 class Matey < ActiveRecord::Base;       belongs_to :pirate    end
-class Parrot < ActiveRecord::Base;      belongs_to :pirate; attr_accessor :cloned_from_id end
 class BattleShip < ActiveRecord::Base;  has_many   :pirates, :as => :ship end
+
+class Parrot < ActiveRecord::Base
+  belongs_to :pirate
+  has_many :parrot_cages, :foreign_key => :owner_id, :inverse_of => :parrot, :class_name => 'Cage'
+  attr_accessor :cloned_from_id
+end
+
+class Cage < ActiveRecord::Base
+  belongs_to :parrot, :foreign_key => :owner_id, :inverse_of => :parrot_cages
+  belongs_to :pirate, :foreign_key => :owner_id, :inverse_of => :pirate_cages
+end
 
 class Pirate < ActiveRecord::Base
   belongs_to :ship, :polymorphic => true
@@ -35,6 +45,7 @@ class Pirate < ActiveRecord::Base
   has_many :treasures, :foreign_key => 'owner'
   has_many :gold_pieces, :through => :treasures
   has_one :parrot
+  has_many :pirate_cages, :inverse_of => :pirate, :foreign_key => :owner_id, :class_name => 'Cage'
 
   serialize :piastres
 

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -25,6 +25,11 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :matey_id, :integer
   end
 
+  create_table :cages, :force => true do |t|
+    t.column :name, :string
+    t.column :owner_id, :integer
+  end
+
   create_table :gold_pieces, :force => true do |t|
     t.column :treasure_id, :integer
   end

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -100,6 +100,15 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     end
   end
 
+  def test_include_association_assignments_with_inverse_of
+    @jack.pirate_cages.build
+    deep_clone = @jack.deep_clone(:include => :pirate_cages)
+    assert deep_clone.new_record?
+    deep_clone.pirate_cages.each do |cage|
+      assert_equal deep_clone, cage.pirate
+    end
+  end
+
   def test_multiple_and_deep_include_association
     deep_clone = @jack.deep_clone(:include => {:treasures => :gold_pieces, :mateys => {}})
     assert deep_clone.new_record?


### PR DESCRIPTION
using only key name can detect wrong association when cloning