### PR TITLE
Nested has many associations

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -48,9 +48,11 @@ class ActiveRecord::Base
           end
 
           if conditions_or_deep_associations.kind_of?(Hash)
+            conditions_or_deep_associations = conditions_or_deep_associations.dup
             conditions[:if]     = conditions_or_deep_associations.delete(:if)     if conditions_or_deep_associations[:if]
             conditions[:unless] = conditions_or_deep_associations.delete(:unless) if conditions_or_deep_associations[:unless]
           elsif conditions_or_deep_associations.kind_of?(Array)
+            conditions_or_deep_associations = conditions_or_deep_associations.dup
             conditions_or_deep_associations.delete_if {|entry| conditions.merge!(entry) if entry.is_a?(Hash) && (entry.key?(:if) || entry.key?(:unless)) }
           end
 
@@ -176,7 +178,7 @@ class ActiveRecord::Base
     def evaluate_conditions object, conditions
       (conditions[:if] && conditions[:if].call(object)) || (conditions[:unless] && !conditions[:unless].call(object))
     end
-    
+
     def normalized_includes_list includes
       list = []
       Array(includes).each do |item|
@@ -186,7 +188,7 @@ class ActiveRecord::Base
           list << item
         end
       end
-      
+
       list
     end
 

--- a/test/models.rb
+++ b/test/models.rb
@@ -127,3 +127,16 @@ class Contractor < ActiveRecord::Base
   belongs_to :building
   has_and_belongs_to_many :apartments
 end
+
+class User < ActiveRecord::Base
+  has_many :orders
+end
+
+class Order < ActiveRecord::Base
+  belongs_to :user
+  has_many :products
+end
+
+class Product < ActiveRecord::Base
+  belongs_to :order
+end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -129,4 +129,18 @@ ActiveRecord::Schema.define(:version => 1) do
     t.column :apartment_id, :integer
     t.column :contractor_id, :integer
   end
+
+  create_table :users, :force => true do |t|
+    t.column :name, :string
+    t.column :contractor_id, :integer
+  end
+
+  create_table :orders, :force => true do |t|
+    t.column :user_id, :integer
+  end
+
+  create_table :products, :force => true do |t|
+    t.column :name, :string
+    t.column :order_id, :integer
+  end
 end

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -430,13 +430,13 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     @order2.products << [@product1, @product2]
     @user.orders << [@order1, @order2]
 
-    deep_clone = @user.deep_clone(:include => [orders: [products: [{ :unless => lambda {|product| product.name == 'Ink' }}]]])
+    deep_clone = @user.deep_clone(:include => [:orders => [:products => [{ :unless => lambda {|product| product.name == 'Ink' }}]]])
 
     assert deep_clone.new_record?
     assert deep_clone.save
     assert_equal 1, deep_clone.orders.second.products.size
 
-    deep_clone = @user.deep_clone(:include => [orders: [products: [{ :if => lambda {|product| product.name == 'Ink'}}]]])
+    deep_clone = @user.deep_clone(:include => [:orders => [:products => [{ :if => lambda {|product| product.name == 'Ink'}}]]])
     assert deep_clone.new_record?
     assert deep_clone.save
     assert_equal 1, deep_clone.orders.second.products.size


### PR DESCRIPTION
When using deeply nested has many associations in include with conditions in include, will the conditional only be called for the first record. This PR is a fix to that bug.

Example: 
``` ruby
class User < ActiveRecord::Base
  has_many :orders
end

class Order < ActiveRecord::Base
  belongs_to :user
  has_many :products
end

class Product < ActiveRecord::Base
  belongs_to :order
end

# Create a user with two orders, each with two products
@user = User.create :name => 'Jack'
@product1 = Product.create  :name => 'Paper'
@product2 = Product.create  :name => 'Ink'
@order1 = Order.create
@order2 = Order.create
@order1.products << [@product1, @product2]
@order2.products << [@product1, @product2]
@user.orders << [@order1, @order2]

# We don't want to clone the "Ink" product
deep_clone = @user.deep_clone(:include => [orders: [products: [{ :unless => lambda {|product| product.name == 'Ink' }}]]])

# However the conditional only works for the first order, because after that is the conditional deleted from the hash
deep_clone.orders[0].products.size #=> 1
deep_clone.orders[1].products.size #=> 2
```