### PR TITLE
Unnecessary check for nil in except and only

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -19,7 +19,7 @@ class ActiveRecord::Base
 
       deep_exceptions = {}
       if options[:except]
-        exceptions = options[:except].nil? ? [] : [options[:except]].flatten
+        exceptions = Array(options[:except])
         exceptions.each do |attribute|
           dup_default_attribute_value_to(kopy, attribute, self) unless attribute.is_a?(Hash)
         end

--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -28,7 +28,7 @@ class ActiveRecord::Base
 
       deep_onlinesses = {}
       if options[:only]
-        onlinesses = options[:only].nil? ? [] : [options[:only]].flatten
+        onlinesses = Array(options[:only])
         object_attrs = kopy.attributes.keys.collect(&:to_sym)
         exceptions = object_attrs - onlinesses
         exceptions.each do |attribute|


### PR DESCRIPTION
Once we check [if options[:except]](https://github.com/moiristo/deep_cloneable/blob/master/lib/deep_cloneable.rb#L21) and [if options[:only]](https://github.com/moiristo/deep_cloneable/blob/master/lib/deep_cloneable.rb#L30) the ternary operators [for exceptions](https://github.com/moiristo/deep_cloneable/blob/master/lib/deep_cloneable.rb#L22) and [for onlies](https://github.com/moiristo/deep_cloneable/blob/master/lib/deep_cloneable.rb#L31) are unnecessary since if they are `nil` they won't get inside the `if condition block`