### PR TITLE
Set association to nil, not false when using unless conditional

### DIFF
--- a/lib/deep_cloneable.rb
+++ b/lib/deep_cloneable.rb
@@ -161,7 +161,7 @@ class ActiveRecord::Base
 
     def deep_cloneable_object_for(single_association, conditions)
       object = send(single_association)
-      evaluate_conditions(object, conditions) && object
+      evaluate_conditions(object, conditions) ? object : nil
     end
 
     def deep_cloneable_objects_for(many_association, conditions)

--- a/test/test_deep_cloneable.rb
+++ b/test/test_deep_cloneable.rb
@@ -436,6 +436,11 @@ class TestDeepCloneable < MiniTest::Unit::TestCase
     assert_equal 2, deep_clone.subjects.size
   end
 
+  def test_should_set_association_to_nil_if_conditionals_fail
+    deep_clone = @jack.deep_clone(:include => { :ship => { :unless => lambda { |ship| ship.name == 'Black Pearl' }}})
+    assert_nil deep_clone.ship
+  end
+
   def test_should_reject_copies_if_conditionals_are_passed_with_associations
     deep_clone = @ship.deep_clone(:include => [:pirates => [:treasures, :mateys, { :unless => lambda { |pirate| pirate.name == 'Jack Sparrow' } }]])
 


### PR DESCRIPTION
Currently when using `unless`, if the expression evaluates to `false`, that value will get set to the association. The correct behavior would be to set the association to `nil`.