### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/deep_cloneable.gemspec
+++ b/deep_cloneable.gemspec
@@ -55,7 +55,7 @@ Gem::Specification.new do |s|
     'test/test_deep_cloneable.rb',
     'test/test_helper.rb'
   ]
-  s.homepage = 'http://github.com/moiristo/deep_cloneable'
+  s.homepage = 'https://github.com/moiristo/deep_cloneable'
   s.licenses = ['MIT']
   s.rubygems_version = '3.0.2'
   s.summary = 'This gem gives every ActiveRecord::Base object the possibility to do a deep clone.'


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/deep_cloneable or some tools or APIs that use the gem's metadata.