### PR TITLE
Add order on deep cloning has_many associations

### DIFF
--- a/lib/deep_cloneable/deep_clone.rb
+++ b/lib/deep_cloneable/deep_clone.rb
@@ -171,7 +171,7 @@ module DeepCloneable
     end
 
     def deep_cloneable_objects_for(many_association, conditions)
-      send(many_association).select { |object| evaluate_conditions(object, conditions) }
+      send(many_association).sort_by(&self.class.reflect_on_association(many_association).klass.primary_key.to_sym).select { |object| evaluate_conditions(object, conditions) }
     end
 
     def process_joined_object_for_deep_clone(object, options, &block)


### PR DESCRIPTION
Currently when cloning a record with has_many associations, the order of the value of primary key of the associated records is not preserved.
PostgreSQL and sqlite3 don't guarantee the order of the primary keys in the result set unless an ORDER BY clause is used.